### PR TITLE
Optimize binary for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,8 @@ gl_generator = "0.14"
 cfg_aliases = "0.2.1"
 
 [profile.release]
-debug = 0
+opt-level = 'z'    # Optimize for size
+lto = true         # Link Time Optimization
+codegen-units = 1  # Slower build but better optimization
+panic = 'abort'    # Don't generate panic unwinding code
+strip = true       # Strip symbols from binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ winit = "*"
 gl_generator = "0.14"
 cfg_aliases = "0.2.1"
 
+# As a small, single shot utility, it makes sense to optimize for size to get a small conda package.
 [profile.release]
 opt-level = 'z'    # Optimize for size
 lto = true         # Link Time Optimization


### PR DESCRIPTION
This is a one shot command, which makes mostly system calls, and performance is not really important.

This reduces the executable size from 670k to 381k.